### PR TITLE
Add support for sensor diagnostics.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,32 @@ cmake_minimum_required(VERSION 3.0.2)
 project(tamagawa_imu_driver)
 
 find_package(catkin REQUIRED COMPONENTS
+  can_msgs
+  diagnostic_msgs
   roscpp
   sensor_msgs
-  can_msgs
 )
 
+find_package(fmt REQUIRED)
+
 catkin_package(
+  CATKIN_DEPENDS
+    can_msgs
+    diagnostic_msgs
+    diagnostic_updater
 )
 
 include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(tag_serial_driver src/tag_serial_driver.cpp)
-target_link_libraries(tag_serial_driver ${catkin_LIBRARIES})
+add_executable(tag_serial_driver
+  src/tag_serial_driver_node.cpp
+  src/tag_serial_driver.cpp
+)
+
+target_link_libraries(tag_serial_driver ${catkin_LIBRARIES} fmt)
 
 add_executable(tag_can_driver src/tag_can_driver.cpp)
 target_link_libraries(tag_can_driver ${catkin_LIBRARIES})

--- a/include/tamagawa_imu_driver/tag_serial_driver.h
+++ b/include/tamagawa_imu_driver/tag_serial_driver.h
@@ -24,12 +24,11 @@
 
 #include <string>
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
+#include <asio/steady_timer.hpp>
 
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <sensor_msgs/Imu.h>
-
-namespace as = boost::asio;
 
 class TagSerialDriver
 {
@@ -40,15 +39,9 @@ public:
   TagSerialDriver();
 
   /**
-   * @brief initialize and open serial port.
-   * @return true on success or false on failure
+   * @brief destructor
    */
-  bool initialize();
-
-  /**
-   * @brief close serial port.
-   */
-  void finalize();
+  ~TagSerialDriver();
 
 private:
   using DiagStatus = diagnostic_msgs::DiagnosticStatus;
@@ -64,14 +57,20 @@ private:
    * @param [in] error Error argument of a handler
    * @param [in] bytes_transfered Bytes transferred argument of a handler
    */
-  void onRead(const boost::system::error_code & error, const std::size_t bytes_transfered);
+  void onRead(const asio::error_code & error, const std::size_t bytes_transfered);
+
+  /**
+   * @brief Handler to be called when the timer expires.
+   * @param [in] error Result of operation
+   */
+  void onReadTimer(const asio::error_code & error);
 
   /**
    * @brief Handler to be called when the write operation completes.
    * @param [in] error Error argument of a handler
    * @param [in] bytes_transfered Bytes transferred argument of a handler
    */
-  void onWrite(const boost::system::error_code & error, std::size_t bytes_transfered);
+  void onWrite(const asio::error_code & error, const std::size_t bytes_transfered);
 
   /**
    * @brief timer callback
@@ -80,22 +79,33 @@ private:
   void onTimer(const ros::TimerEvent & event);
 
   /**
- * @brief verify checksum
- * @param [in] data start of message
- * @return true on success or false on failure
- */
+   * @brief initialize and open serial port.
+   */
+  void initialize();
+
+  /**
+   * @brief close serial port.
+   */
+  void finalize();
+
+  /**
+   * @brief verify checksum
+   * @param [in] data start of message
+   * @return true on success or false on failure
+   */
   bool verifyChecksum(const std::string & data);
 
   ros::NodeHandle nh_{""};    //!< @brief ros node handle
   ros::NodeHandle pnh_{"~"};  //!< @brief private ros node handle
 
-  ros::Publisher pub_;        //!< @brief publisher for IMU data
+  ros::Publisher pub_imu_;    //!< @brief publisher for IMU data
   sensor_msgs::Imu imu_msg_;  //!< @brief IMU message
   std::string imu_frame_id_;  //!< @brief frame ID for sensor data
   std::string port_;          //!< @brief serial port name
-  as::io_service io_;         //!< @brief facilities of custom asynchronous services
-  boost::shared_ptr<as::serial_port> serial_port_;  //!< @brief wrapper over serial port
-  as::streambuf buffer_;                            //!< @brief Received data
+  asio::io_service io_;       //!< @brief facilities of custom asynchronous services
+  std::shared_ptr<asio::serial_port> serial_port_;  //!< @brief wrapper over serial port
+  std::shared_ptr<asio::steady_timer> read_timer_;  //!< @brief timer based on the steady clock
+  asio::streambuf buffer_;                          //!< @brief Received data
   bool is_checksum_ok_;                  //!< @brief flag if checksum error is occuring or not
   uint64_t receive_count_;               //!< @brief counter of received data
   uint16_t imu_status_;                  //!< @brief  IMU status

--- a/include/tamagawa_imu_driver/tag_serial_driver.h
+++ b/include/tamagawa_imu_driver/tag_serial_driver.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Tier IV, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TAMAGAWA_IMU_DRIVER_TAG_SERIAL_DRIVER_H_
+#define TAMAGAWA_IMU_DRIVER_TAG_SERIAL_DRIVER_H_
+
+/**
+ * @file tag_serial_driver.h
+ * @brief Tamagawa IMU serial driver class
+ */
+
+#include <string>
+
+#include <boost/asio.hpp>
+
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <sensor_msgs/Imu.h>
+
+namespace as = boost::asio;
+
+class TagSerialDriver
+{
+public:
+  /**
+   * @brief constructor
+   */
+  TagSerialDriver();
+
+  /**
+   * @brief initialize and open serial port.
+   * @return true on success or false on failure
+   */
+  bool initialize();
+
+  /**
+   * @brief close serial port.
+   */
+  void finalize();
+
+private:
+  using DiagStatus = diagnostic_msgs::DiagnosticStatus;
+
+  /**
+   * @brief check IMU status
+   * @param [out] stat diagnostic message passed directly to diagnostic publish calls
+   */
+  void checkStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  /**
+   * @brief Handler to be called when the read operation completes.
+   * @param [in] error Error argument of a handler
+   * @param [in] bytes_transfered Bytes transferred argument of a handler
+   */
+  void onRead(const boost::system::error_code & error, const std::size_t bytes_transfered);
+
+  /**
+   * @brief Handler to be called when the write operation completes.
+   * @param [in] error Error argument of a handler
+   * @param [in] bytes_transfered Bytes transferred argument of a handler
+   */
+  void onWrite(const boost::system::error_code & error, std::size_t bytes_transfered);
+
+  /**
+   * @brief timer callback
+   * @param [in] event timing information
+   */
+  void onTimer(const ros::TimerEvent & event);
+
+  /**
+ * @brief verify checksum
+ * @param [in] data start of message
+ * @return true on success or false on failure
+ */
+  bool verifyChecksum(const std::string & data);
+
+  ros::NodeHandle nh_{""};    //!< @brief ros node handle
+  ros::NodeHandle pnh_{"~"};  //!< @brief private ros node handle
+
+  ros::Publisher pub_;        //!< @brief publisher for IMU data
+  sensor_msgs::Imu imu_msg_;  //!< @brief IMU message
+  std::string imu_frame_id_;  //!< @brief frame ID for sensor data
+  std::string port_;          //!< @brief serial port name
+  as::io_service io_;         //!< @brief facilities of custom asynchronous services
+  boost::shared_ptr<as::serial_port> serial_port_;  //!< @brief wrapper over serial port
+  as::streambuf buffer_;                            //!< @brief Received data
+  bool is_checksum_ok_;                  //!< @brief flag if checksum error is occuring or not
+  uint64_t receive_count_;               //!< @brief counter of received data
+  uint16_t imu_status_;                  //!< @brief  IMU status
+  ros::Timer timer_;                     //!< @brief timer
+  diagnostic_updater::Updater updater_;  //!< @brief updater class which advertises to /diagnostics
+};
+
+#endif  // TAMAGAWA_IMU_DRIVER_TAG_SERIAL_DRIVER_H_

--- a/include/tamagawa_imu_driver/tag_serial_driver.h
+++ b/include/tamagawa_imu_driver/tag_serial_driver.h
@@ -89,6 +89,11 @@ private:
   void finalize();
 
   /**
+   * @brief receive data from serial port.
+   */
+  void receive();
+
+  /**
    * @brief verify checksum
    * @param [in] data start of message
    * @return true on success or false on failure

--- a/launch/serial.launch
+++ b/launch/serial.launch
@@ -1,7 +1,5 @@
 <launch>
-  <arg name="respawn" default="true" />
-  <arg name="respawn_delay" default="30" />
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" respawn="$(arg respawn)" respawn_delay="$(arg respawn_delay)">
+  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver">
     <param name="port" value="/dev/imu" />
     <param name="imu_frame_id" value="tamagawa/imu_link" />
   </node>

--- a/launch/serial.launch
+++ b/launch/serial.launch
@@ -1,0 +1,6 @@
+<launch>
+  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver">
+    <param name="port" value="/dev/imu" />
+    <param name="imu_frame_id" value="tamagawa/imu_link" />
+  </node>
+</launch>

--- a/launch/serial.launch
+++ b/launch/serial.launch
@@ -1,5 +1,7 @@
 <launch>
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver">
+  <arg name="respawn" default="true" />
+  <arg name="respawn_delay" default="30" />
+  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" respawn="$(arg respawn)" respawn_delay="$(arg respawn_delay)">
     <param name="port" value="/dev/imu" />
     <param name="imu_frame_id" value="tamagawa/imu_link" />
   </node>

--- a/launch/serial_AU7554N.launch
+++ b/launch/serial_AU7554N.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<launch>
-
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" args="/dev/ttyUSB0" "noGPS" "100"/>
-
-</launch>

--- a/launch/serial_TAG250_Nxx00.launch
+++ b/launch/serial_TAG250_Nxx00.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<launch>
-
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" args="/dev/ttyUSB0 noGPS 100" output="screen"/>
-
-</launch>

--- a/launch/serial_TAG250_Nxx40.launch
+++ b/launch/serial_TAG250_Nxx40.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<launch>
-
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" args="/dev/ttyUSB0" "withGPS" "100"/>
-
-</launch>

--- a/launch/serial_TAG264.launch
+++ b/launch/serial_TAG264.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<launch>
-
-  <node pkg="tamagawa_imu_driver" name="tag_serial_driver" type="tag_serial_driver" args="/dev/ttyUSB0" "withGPS" "50"/>
-
-</launch>

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,8 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>asio</depend>
   <depend>can_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/package.xml
+++ b/package.xml
@@ -9,21 +9,17 @@
 
   <license>Apache 2</license>
 
-
   <maintainer email="osamu.sekino@tier4.jp">Osamu Sekino</maintainer>
 
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>can_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>can_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>can_msgs</exec_depend>
+  <depend>can_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
+  <depend>fmt</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
 
   <export>
   </export>

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -158,7 +158,10 @@ void TagSerialDriver::checkStatus(diagnostic_updater::DiagnosticStatusWrapper & 
 void TagSerialDriver::onRead(const asio::error_code & error, const std::size_t bytes_transfered)
 {
   if (error) {
-    ROS_ERROR("Read error: %s", error.message().c_str());
+    if (error != asio::error::operation_aborted) {
+      ROS_ERROR("Read error: %s", error.message().c_str());
+    }
+    return;
   } else {
     std::ostringstream oss;
     oss << &buffer_;
@@ -210,7 +213,9 @@ void TagSerialDriver::onReadTimer(const asio::error_code & error)
   if (error) {
     ROS_DEBUG("Timer canceled. Data received successfully.");
   } else {
-    throw std::runtime_error("Timer expired, Could not receive any data from sensor.");
+    ROS_WARN("Read timeout. Retrying to connect.");
+    finalize();
+    initialize();
   }
 }
 

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -120,17 +120,23 @@ void TagSerialDriver::initialize()
                           &TagSerialDriver::onWrite, this, asio::placeholders::error,
                           asio::placeholders::bytes_transferred));
 
-  asio::async_read_until(
-    *serial_port_, buffer_, "\n",
-    boost::bind(
-      &TagSerialDriver::onRead, this, asio::placeholders::error,
-      asio::placeholders::bytes_transferred));
+  receive();
 }
 
 void TagSerialDriver::finalize()
 {
   serial_port_->close();
   io_.stop();
+}
+
+void TagSerialDriver::receive()
+{
+  // asynchronously read data
+  asio::async_read_until(
+    *serial_port_, buffer_, "\n",
+    boost::bind(
+      &TagSerialDriver::onRead, this, asio::placeholders::error,
+      asio::placeholders::bytes_transferred));
 }
 
 void TagSerialDriver::checkStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -200,12 +206,7 @@ void TagSerialDriver::onRead(const asio::error_code & error, const std::size_t b
     }
   }
 
-  // asynchronously read data
-  asio::async_read_until(
-    *serial_port_, buffer_, "\n",
-    boost::bind(
-      &TagSerialDriver::onRead, this, asio::placeholders::error,
-      asio::placeholders::bytes_transferred));
+  receive();
 }
 
 void TagSerialDriver::onReadTimer(const asio::error_code & error)

--- a/src/tag_serial_driver_node.cpp
+++ b/src/tag_serial_driver_node.cpp
@@ -29,13 +29,7 @@ int main(int argc, char ** argv)
 
   TagSerialDriver driver;
 
-  // Initialize and open serial port
-  if (!driver.initialize()) return -1;
-
   ros::spin();
-
-  // Close serial port
-  driver.finalize();
 
   return 0;
 }

--- a/src/tag_serial_driver_node.cpp
+++ b/src/tag_serial_driver_node.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Tier IV, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file tag_serial_driver_node.cpp
+ * @brief Tamagawa IMU Driver node class
+ */
+
+#include <ros/ros.h>
+
+#include <tamagawa_imu_driver/tag_serial_driver.h>
+
+int main(int argc, char ** argv)
+{
+  ros::init(argc, argv, "tag_serial_driver");
+
+  TagSerialDriver driver;
+
+  // Initialize and open serial port
+  if (!driver.initialize()) return -1;
+
+  ros::spin();
+
+  // Close serial port
+  driver.finalize();
+
+  return 0;
+}


### PR DESCRIPTION
## PRの種類

- [x] 新機能
- [ ] 既存機能の性能向上
- [ ] バグフィックス

## Jiraリンク
https://tier4.atlassian.net/browse/DEVLEAD-1033

## 変更概要
センサーダイアグ対応。https://github.com/tier4/autoware.iv/pull/795 
Fork版tamagawa_imu_driverに対して以下対応を行いました。

- チェックサムエラー検出、ダイアグトピック出力を追加。
- BINデータ送信要求のデータに誤りがあったため修正。
- 使用されていないと思われるコードやlaunchファイルを削除。
- CANについてはそのままとしています。

なお、通信途絶については、autoware_state_monitorにてIMUデータのトピックを監視していただきたく思います。

## レビュー方法
IMUのセンサードライバが、ダイアグ用メッセージを出力していることをTopic Monitorなどで確認する。

## その他
- [ ] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
※ v0.7.0に組込み予定。