### PR TITLE
fix: suppress warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 ### Find Packages

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -95,7 +95,7 @@ int serial_setup(const char * device)
 void receive_ver_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char ver_req[] = "$TSC,VER*29\x0d\x0a";
-  write(fd, ver_req, sizeof(ver_req));
+  [[maybe_unused]] int ver_req_data = write(fd, ver_req, sizeof(ver_req));
   RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request:%s", ver_req);
 }
 
@@ -103,14 +103,14 @@ void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char offset_cancel_req[32];
   sprintf(offset_cancel_req, "$TSC,OFC,%d\x0d\x0a", msg->data);
-  write(fd, offset_cancel_req, sizeof(offset_cancel_req));
+  [[maybe_unused]] int offset_cancel_req_data = write(fd, offset_cancel_req, sizeof(offset_cancel_req));
   RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
 }
 
 void receive_heading_reset_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char heading_reset_req[] = "$TSC,HRST*29\x0d\x0a";
-  write(fd, heading_reset_req, sizeof(heading_reset_req));
+  [[maybe_unused]] int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
   RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
 }
 

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -99,7 +99,7 @@ void receive_ver_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr
   if (ver_req_data >= 0) {
     RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request:%s", ver_req);
   } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Version Request: error");
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Version Request: %s", ver_req);
   }
 }
 
@@ -111,7 +111,7 @@ void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
   if (offset_cancel_req_data >= 0) {
     RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
   } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request: error");
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Offset Cancel Request: %s", offset_cancel_req);
   }
 
 }
@@ -123,7 +123,7 @@ void receive_heading_reset_req([[maybe_unused]] const std_msgs::msg::Int32::Cons
   if (heading_reset_req_data >= 0) {
     RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
   } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request: error");
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Heading reset Request: %s", heading_reset_req);
   }
 }
 

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -95,23 +95,36 @@ int serial_setup(const char * device)
 void receive_ver_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char ver_req[] = "$TSC,VER*29\x0d\x0a";
-  [[maybe_unused]] int ver_req_data = write(fd, ver_req, sizeof(ver_req));
-  RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request:%s", ver_req);
+  int ver_req_data = write(fd, ver_req, sizeof(ver_req));
+  if (ver_req_data >= 0) {
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request:%s", ver_req);
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Version Request: error");
+  }
 }
 
 void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char offset_cancel_req[32];
   sprintf(offset_cancel_req, "$TSC,OFC,%d\x0d\x0a", msg->data);
-  [[maybe_unused]] int offset_cancel_req_data = write(fd, offset_cancel_req, sizeof(offset_cancel_req));
-  RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
+  int offset_cancel_req_data = write(fd, offset_cancel_req, sizeof(offset_cancel_req));
+  if (offset_cancel_req_data >= 0) {
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request: error");
+  }
+
 }
 
 void receive_heading_reset_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char heading_reset_req[] = "$TSC,HRST*29\x0d\x0a";
-  [[maybe_unused]] int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
-  RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
+  int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
+  if (heading_reset_req_data >= 0) {
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request: error");
+  }
 }
 
 void shutdown_cmd([[maybe_unused]] int sig)

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -92,7 +92,7 @@ int serial_setup(const char * device)
   return fd;
 }
 
-void receive_ver_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
+void receive_ver_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char ver_req[] = "$TSC,VER*29\x0d\x0a";
   [[maybe_unused]] int ver_req_data = write(fd, ver_req, sizeof(ver_req));
@@ -107,14 +107,14 @@ void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
   RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
 }
 
-void receive_heading_reset_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
+void receive_heading_reset_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
 {
   char heading_reset_req[] = "$TSC,HRST*29\x0d\x0a";
   [[maybe_unused]] int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
   RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
 }
 
-void shutdown_cmd(int sig)
+void shutdown_cmd([[maybe_unused]] int sig)
 {
   tcsetattr(fd, TCSANOW, &old_conf_tio);  // Revert to previous settings
   close(fd);

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -97,7 +97,7 @@ void receive_ver_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr
   char ver_req[] = "$TSC,VER*29\x0d\x0a";
   int ver_req_data = write(fd, ver_req, sizeof(ver_req));
   if (ver_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request:%s", ver_req);
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request: %s", ver_req);
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Version Request: %s", ver_req);
   }
@@ -109,7 +109,7 @@ void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
   sprintf(offset_cancel_req, "$TSC,OFC,%d\x0d\x0a", msg->data);
   int offset_cancel_req_data = write(fd, offset_cancel_req, sizeof(offset_cancel_req));
   if (offset_cancel_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request:%s", offset_cancel_req);
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request: %s", offset_cancel_req);
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Offset Cancel Request: %s", offset_cancel_req);
   }
@@ -121,7 +121,7 @@ void receive_heading_reset_req([[maybe_unused]] const std_msgs::msg::Int32::Cons
   char heading_reset_req[] = "$TSC,HRST*29\x0d\x0a";
   int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
   if (heading_reset_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request:%s", heading_reset_req);
+    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request: %s", heading_reset_req);
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Heading reset Request: %s", heading_reset_req);
   }


### PR DESCRIPTION
This PR has  two changes.
- fix followings

```
--- stderr: tamagawa_imu_driver                                                                                                                                                                                
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void receive_ver_req(std_msgs::msg::Int32_<std::allocator<void> >::ConstSharedPtr)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:98:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
   98 |   write(fd, ver_req, sizeof(ver_req));
      |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void receive_offset_cancel_req(std_msgs::msg::Int32_<std::allocator<void> >::ConstSharedPtr)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:106:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  106 |   write(fd, offset_cancel_req, sizeof(offset_cancel_req));
      |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void receive_heading_reset_req(std_msgs::msg::Int32_<std::allocator<void> >::ConstSharedPtr)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:113:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  113 |   write(fd, heading_reset_req, sizeof(heading_reset_req));
      |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---
--- stderr: tamagawa_imu_driver                               
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void receive_ver_req(std_msgs::msg::Int32_<std::allocator<void> >::ConstSharedPtr)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:95:65: error: unused parameter ‘msg’ [-Werror=unused-parameter]
   95 | void receive_ver_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void receive_heading_reset_req(std_msgs::msg::Int32_<std::allocator<void> >::ConstSharedPtr)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:110:75: error: unused parameter ‘msg’ [-Werror=unused-parameter]
  110 | void receive_heading_reset_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp: In function ‘void shutdown_cmd(int)’:
/home/hrkota/autoware.proj.s1.universe/src/vendor/tamagawa_imu_driver/src/tag_serial_driver.cpp:117:23: error: unused parameter ‘sig’ [-Werror=unused-parameter]
  117 | void shutdown_cmd(int sig)
```

- Add Werror and delete Wunused-parameter