### PR TITLE
feat: add diagnostics for rate monitoring

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>diagnostic_updater</depend>
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>

--- a/src/rate_bound_status.hpp
+++ b/src/rate_bound_status.hpp
@@ -1,0 +1,280 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RATE_BOUND_STATUS_HPP_
+#define RATE_BOUND_STATUS_HPP_
+
+#include <diagnostic_updater/diagnostic_updater.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
+#include <chrono>
+#include <iomanip>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+namespace custom_diagnostic_tasks
+{
+/**
+ * \brief A structure that holds the constructor parameters for the
+ * RateBoundStatus class.
+ */
+struct RateBoundStatusParam
+{
+  RateBoundStatusParam(const double min_freq, const double max_freq)
+      : min_frequency(min_freq), max_frequency(max_freq){}
+
+  double min_frequency;
+  double max_frequency;
+};
+
+/**
+ * \brief Diagnostic task to monitor the interval between events.
+ *
+ * This diagnostic task monitors the difference between consecutive events,
+ * and creates corresponding diagnostics. This task categorize observed intervals into
+ * OK/WARN/ERROR according to the value ranges passed via constructor arguments
+ */
+class RateBoundStatus : public diagnostic_updater::DiagnosticTask
+{
+private:
+  // Helper struct to express state machine nodes
+  struct StateBase
+  {
+    StateBase(const unsigned char lv, const std::string m)
+        : level(lv), num_observations(1), msg(m) {}
+
+    unsigned char level;
+    size_t num_observations;
+    std::string msg;
+  };
+
+  struct Stale : public StateBase
+  {
+    Stale()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::STALE,
+                    "Topic has not been received yet") {}
+  };
+
+  struct Ok : public StateBase
+  {
+    Ok()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::OK,
+                    "Rate is reasonable") {}
+  };
+
+  struct Warn : public StateBase
+  {
+    Warn()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::WARN,
+                    "Rate is within warning range") {}
+  };
+
+  struct Error : public StateBase
+  {
+    Error()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+                    "Rate is out of valid range") {}
+  };
+
+  using StateHolder = std::variant<Stale, Ok, Warn, Error>;
+
+ public:
+  /**
+   * \brief Constructs RateBoundstatus, which inherits diagnostic_updater::DiagnosticTask.
+   *
+   * \param ok_params The pair of min/max frequency for the topic rate to be recognized as "OK".
+   * \param warn_params The pair of min/max frequency for the topic rate to be recognized as "WARN".
+   * These values should have a wider range than `ok_params`.
+   * \param num_frame_transition The number of the successive observations for the status
+   * transition. E.g., the status will not be changed from OK to WARN until successive
+   * `num_frame_transition` WARNs are observed.
+   * \param immediate_error_report If true (default), errors related to the rate bounds will be
+   * reported immediately once observed; otherwise, the hysteresis damping method using
+   * `num_frame_transition` will be adopted
+   * \param name The arbitrary string to be assigned for this diagnostic task.
+   * This name will not be exposed in the actual published topics.
+   */
+  RateBoundStatus(const RateBoundStatusParam& ok_params,
+                  const RateBoundStatusParam& warn_params,
+                  const size_t num_frame_transition = 1,
+                  const bool immediate_error_report = true,
+                  const std::string& name = "rate bound check")
+      : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
+        num_frame_transition_(num_frame_transition),
+        immediate_error_report_(immediate_error_report), zero_seen_(false),
+        candidate_state_(Stale{}), current_state_(Stale{})
+  {
+    if (num_frame_transition < 1) {
+      num_frame_transition_ = 1;
+    }
+
+    // Confirm `warn_params` surely has wider range than `ok_params`
+    if (warn_params_.min_frequency >= ok_params_.min_frequency ||
+      ok_params_.max_frequency >= warn_params_.max_frequency) {
+      throw std::runtime_error(
+          "Invalid range parameters were detected. warn_params should specify a range "
+          "that includes a range of ok_params.");
+    }
+  }
+
+  /**
+   * \brief Calculate the frequency of how much this function is called
+   *
+   */
+  void tick()
+  {
+    std::unique_lock<std::mutex> lock(lock_);
+    double stamp = std::chrono::duration<double>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    if (!previous_frame_timestamp_) {
+      zero_seen_ = true;
+    } else {
+      zero_seen_ = false;
+      double delta = stamp - previous_frame_timestamp_.value();
+      frequency_ = (delta < 10 * std::numeric_limits<double>::epsilon()) ?
+                   std::numeric_limits<double>::infinity() : 1. / delta;
+    }
+    previous_frame_timestamp_ = stamp;
+  }
+
+  /**
+   * \brief function called every update
+   */
+  void run(diagnostic_updater::DiagnosticStatusWrapper& stat) override
+  {
+    std::unique_lock<std::mutex> lock(lock_);
+
+    // classify the current observation
+    StateHolder frame_result;
+    if (!frequency_ || zero_seen_) {
+      frame_result.emplace<Stale>();
+    } else {
+      if (ok_params_.min_frequency < frequency_ && frequency_ < ok_params_.max_frequency) {
+        frame_result.emplace<Ok>();
+      } else if ((warn_params_.min_frequency <= frequency_ && frequency_ <= ok_params_.min_frequency) ||
+                 (ok_params_.max_frequency <= frequency_ && frequency_ <= warn_params_.max_frequency)) {
+        frame_result.emplace<Warn>();
+      } else {
+        frame_result.emplace<Error>();
+      }
+    }
+
+    // If the classify result is same as previous one, count the number of observation
+    // Otherwise, update candidate
+    if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
+      std::visit([](auto& s){
+        s.num_observations += 1;
+      }, candidate_state_);
+    } else {
+      candidate_state_ = frame_result;
+    }
+
+    // Update the current state if
+    // - immediate error report is required and the observed state is error
+    // - Or the same state is observed multiple times
+    if ((immediate_error_report_ && std::holds_alternative<Error>(candidate_state_)) ||
+        (get_num_observations(candidate_state_) >= num_frame_transition_)) {
+      current_state_ = candidate_state_;
+      std::visit([](auto& s) {
+        s.num_observations = 1;
+      }, candidate_state_);
+    }
+
+    stat.summary(get_level(current_state_), get_msg(current_state_));
+
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
+    stat.add("Publish rate", ss.str());
+
+    ss.str("");  // reset contents
+    ss << get_level_string(get_level(frame_result));
+    stat.add("Rate status", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << ok_params_.min_frequency;
+    stat.add("Minimum OK rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << ok_params_.max_frequency;
+    stat.add("Maximum OK rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << warn_params_.min_frequency;
+    stat.add("Minimum WARN rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency;
+    stat.add("Maximum WARN rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << get_num_observations(candidate_state_);
+    stat.add("Observed frames", ss.str());
+
+    ss.str("");  // reset contents
+    ss << num_frame_transition_;
+    stat.add("Observed frames transition threshold", ss.str());
+  }
+
+protected:
+  RateBoundStatusParam ok_params_;
+  RateBoundStatusParam warn_params_;
+  size_t num_frame_transition_;
+  bool immediate_error_report_;
+  bool zero_seen_;
+  std::optional<double> frequency_;
+  std::optional<double> previous_frame_timestamp_;
+  std::mutex lock_;
+
+  StateHolder candidate_state_;
+  StateHolder current_state_;
+
+  static unsigned char get_level(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.level;}, state);
+  }
+
+  static size_t get_num_observations(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.num_observations;}, state);
+  }
+
+  static std::string get_msg(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.msg;}, state);
+  }
+
+  static std::string get_level_string(unsigned char level) {
+    switch(level) {
+      case diagnostic_msgs::msg::DiagnosticStatus::OK:
+        return "OK";
+      case diagnostic_msgs::msg::DiagnosticStatus::WARN:
+        return "WARN";
+      case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+        return "ERROR";
+      case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+        return "STALE";
+      default:
+        return "UNDEFINED";
+    }
+  }
+
+};  // class RateBoundStatus
+
+}  // namespace custom_diagnostic_tasks
+
+#endif  // RATE_BOUND_STATUS_HPP_

--- a/src/rate_bound_status.hpp
+++ b/src/rate_bound_status.hpp
@@ -19,11 +19,11 @@
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
-#include <chrono>
 #include <iomanip>
 #include <limits>
 #include <mutex>
 #include <optional>
+#include <rcl/time.h>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -99,6 +99,7 @@ private:
   /**
    * \brief Constructs RateBoundstatus, which inherits diagnostic_updater::DiagnosticTask.
    *
+   * \param parent_node The parent node from which the parameters and clock are retrieved.
    * \param ok_params The pair of min/max frequency for the topic rate to be recognized as "OK".
    * \param warn_params The pair of min/max frequency for the topic rate to be recognized as "WARN".
    * These values should have a wider range than `ok_params`.
@@ -111,7 +112,8 @@ private:
    * \param name The arbitrary string to be assigned for this diagnostic task.
    * This name will not be exposed in the actual published topics.
    */
-  RateBoundStatus(const RateBoundStatusParam& ok_params,
+  RateBoundStatus(const rclcpp::Node* parent_node,
+                  const RateBoundStatusParam& ok_params,
                   const RateBoundStatusParam& warn_params,
                   const size_t num_frame_transition = 1,
                   const bool immediate_error_report = true,
@@ -132,6 +134,17 @@ private:
           "Invalid range parameters were detected. warn_params should specify a range "
           "that includes a range of ok_params.");
     }
+
+    // select clock according to the use_sim_time paramter set to the parent
+    bool use_sim_time = false;
+    if (parent_node->has_parameter("use_sim_time")) {
+      use_sim_time = parent_node->get_parameter("use_sim_time").as_bool();
+    }
+    if (use_sim_time) {
+      clock_ = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    } else {
+      clock_ = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+    }
   }
 
   /**
@@ -141,8 +154,7 @@ private:
   void tick()
   {
     std::unique_lock<std::mutex> lock(lock_);
-    double stamp = std::chrono::duration<double>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
+    double stamp = get_now();
 
     if (!previous_frame_timestamp_) {
       zero_seen_ = true;
@@ -177,6 +189,24 @@ private:
       }
     }
 
+    // check the latest update is valid one
+    size_t num_frame_skipped = 0;
+    bool is_valid_observation = true;
+    if (previous_frame_timestamp_) {
+      double stamp = get_now();
+      double delta = stamp - previous_frame_timestamp_.value();
+      double freq_from_prev_tick = 1. / delta;
+      // If the latest update too older than warn_params_ criteria, frame_result fires error
+      if (freq_from_prev_tick < warn_params_.min_frequency) {
+        frame_result.emplace<Error>();
+        is_valid_observation = false;
+        frequency_ = freq_from_prev_tick;
+        auto max_frame_period_s = 1. / warn_params_.min_frequency;
+        // Minimum frames to assume skipped if 'tick' calls occur at 'warn_params_.min_frequency'.
+        num_frame_skipped  = static_cast<size_t>(delta / max_frame_period_s);
+      }
+    }
+
     // If the classify result is same as previous one, count the number of observation
     // Otherwise, update candidate
     if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
@@ -191,7 +221,8 @@ private:
     // - immediate error report is required and the observed state is error
     // - Or the same state is observed multiple times
     if ((immediate_error_report_ && std::holds_alternative<Error>(candidate_state_)) ||
-        (get_num_observations(candidate_state_) >= num_frame_transition_)) {
+        (is_valid_observation && get_num_observations(candidate_state_) >= num_frame_transition_) ||
+        (!is_valid_observation && num_frame_skipped >= num_frame_transition_)) {
       current_state_ = candidate_state_;
       std::visit([](auto& s) {
         s.num_observations = 1;
@@ -229,6 +260,10 @@ private:
     stat.add("Observed frames", ss.str());
 
     ss.str("");  // reset contents
+    ss << num_frame_skipped;
+    stat.add("Assumed skipped frames", ss.str());
+
+    ss.str("");  // reset contents
     ss << num_frame_transition_;
     stat.add("Observed frames transition threshold", ss.str());
   }
@@ -245,6 +280,12 @@ protected:
 
   StateHolder candidate_state_;
   StateHolder current_state_;
+
+  std::shared_ptr<rclcpp::Clock> clock_;
+
+  inline double get_now() {
+    return clock_->now().seconds();
+  }
 
   static unsigned char get_level(const StateHolder& state) {
     return std::visit([](const auto& s){return s.level;}, state);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -110,21 +110,17 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("tag_can_driver");
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
-  auto rel_ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_ok.min", 0.95);
-  auto rel_ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_ok.max", 1.05);
-  auto rel_warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_warn.min", 0.9);
-  auto rel_warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_warn.max", 1.1);
+  auto ok_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.min", 190);
+  auto ok_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.max", 210);
+  auto warn_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.min", 180);
+  auto warn_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.max", 220);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
-    node.get(),
-    custom_diagnostic_tasks::RateBoundStatusParam(
-      frequency_reference * rel_ok_min_freq, frequency_reference * rel_ok_max_freq),
-    custom_diagnostic_tasks::RateBoundStatusParam(
-      frequency_reference * rel_warn_min_freq, frequency_reference * rel_warn_max_freq),
-    3);
+    node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
+    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -50,7 +50,13 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 
+#include "rate_bound_status.hpp"
+#include <memory>
+
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
+std::unique_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
+std::unique_ptr<diagnostic_updater::Updater> diag_updater;
+std::unique_ptr<diagnostic_updater::CompositeDiagnosticTask> diag_composer;
 
 uint16_t counter;
 int16_t angular_velocity_x_raw = 0;
@@ -93,6 +99,7 @@ void receive_CAN(const can_msgs::msg::Frame::ConstSharedPtr msg)
     imu_msg.orientation.z = 0.0;
     imu_msg.orientation.w = 1.0;
     pub->publish(imu_msg);
+    rate_bound_status->tick();
   }
 }
 
@@ -102,6 +109,19 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("tag_can_driver");
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
+  auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
+  rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
+    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
+    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
+    3
+  );
+  diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
+  diag_updater->setHardwareID(imu_frame_id);
+  diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
+  diag_composer->addTask(&(*rate_bound_status));
+  diag_updater->setPeriod(1.0 / target_frequency);
+  diag_updater->add(*diag_composer);
+  diag_updater->force_update();
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);
   pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 100);
   rclcpp::spin(node);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -109,18 +109,27 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("tag_can_driver");
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
-  auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
+  auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
+  auto rel_ok_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_ok.min", 0.95);
+  auto rel_ok_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_ok.max", 1.05);
+  auto rel_warn_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_warn.min", 0.9);
+  auto rel_warn_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_warn.max", 1.1);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(),
-    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
-    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
-    3
-  );
+    custom_diagnostic_tasks::RateBoundStatusParam(
+      frequency_reference * rel_ok_min_freq, frequency_reference * rel_ok_max_freq),
+    custom_diagnostic_tasks::RateBoundStatusParam(
+      frequency_reference * rel_warn_min_freq, frequency_reference * rel_warn_max_freq),
+    3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
   diag_composer->addTask(&(*rate_bound_status));
-  diag_updater->setPeriod(1.0 / target_frequency);
+  diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*diag_composer);
   diag_updater->force_update();
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -124,7 +124,7 @@ int main(int argc, char ** argv)
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
-  diag_composer->addTask(&(*rate_bound_status));
+  diag_composer->addTask(rate_bound_status.get());
   diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*diag_composer);
   diag_updater->force_update();

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -56,7 +56,6 @@
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
 std::unique_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
 std::unique_ptr<diagnostic_updater::Updater> diag_updater;
-std::unique_ptr<diagnostic_updater::CompositeDiagnosticTask> diag_composer;
 
 uint16_t counter;
 int16_t angular_velocity_x_raw = 0;
@@ -118,15 +117,14 @@ int main(int argc, char ** argv)
     "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
   auto warn_max_freq = node->declare_parameter<double>(
     "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
+  node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
     custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
-  diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
-  diag_composer->addTask(rate_bound_status.get());
   diag_updater->setPeriod(1.0 / frequency_reference);
-  diag_updater->add(*diag_composer);
+  diag_updater->add(*rate_bound_status);
   diag_updater->force_update();
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);
   pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 100);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -111,13 +111,13 @@ int main(int argc, char ** argv)
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
   auto ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.min", 190);
+    "diagnostics.rate_bound_status.frequency_ok.min_hz", 190.0);
   auto ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.max", 210);
+    "diagnostics.rate_bound_status.frequency_ok.max_hz", 210.0);
   auto warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.min", 180);
+    "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
   auto warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.max", 220);
+    "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
     custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -110,17 +110,17 @@ int main(int argc, char ** argv)
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
   auto ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.min_hz", 190.0);
+    "diagnostics.rate_bound_status.frequency_ok.min_hz", 195.0);
   auto ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.max_hz", 210.0);
+    "diagnostics.rate_bound_status.frequency_ok.max_hz", 205.0);
   auto warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
+    "diagnostics.rate_bound_status.frequency_warn.min_hz", 190.0);
   auto warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
+    "diagnostics.rate_bound_status.frequency_warn.max_hz", 210.0);
   node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
-    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
+    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3, false);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_updater->setPeriod(1.0 / frequency_reference);

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -111,6 +111,7 @@ int main(int argc, char ** argv)
   imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
   auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
+    node.get(),
     custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
     custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
     3

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -176,17 +176,17 @@ int main(int argc, char ** argv)
 
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
   auto ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.min_hz", 190.0);
+    "diagnostics.rate_bound_status.frequency_ok.min_hz", 195.0);
   auto ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.max_hz", 210.0);
+    "diagnostics.rate_bound_status.frequency_ok.max_hz", 205.0);
   auto warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
+    "diagnostics.rate_bound_status.frequency_warn.min_hz", 190.0);
   auto warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
+    "diagnostics.rate_bound_status.frequency_warn.max_hz", 210.0);
   node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
-    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
+    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3, false);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_updater->setPeriod(1.0 / frequency_reference);

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -75,7 +75,6 @@ int raw_data;
 sensor_msgs::msg::Imu imu_msg;
 std::unique_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
 std::unique_ptr<diagnostic_updater::Updater> diag_updater;
-std::unique_ptr<diagnostic_updater::CompositeDiagnosticTask> diag_composer;
 
 int serial_setup(const char * device)
 {
@@ -184,15 +183,14 @@ int main(int argc, char ** argv)
     "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
   auto warn_max_freq = node->declare_parameter<double>(
     "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
+  node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
     custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
-  diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
-  diag_composer->addTask(rate_bound_status.get());
   diag_updater->setPeriod(1.0 / frequency_reference);
-  diag_updater->add(*diag_composer);
+  diag_updater->add(*rate_bound_status);
   diag_updater->force_update();
 
   while (rclcpp::ok()) {

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -175,18 +175,27 @@ int main(int argc, char ** argv)
   imu_msg.orientation.z = 0.0;
   imu_msg.orientation.w = 1.0;
 
-  auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
+  auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
+  auto rel_ok_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_ok.min", 0.95);
+  auto rel_ok_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_ok.max", 1.05);
+  auto rel_warn_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_warn.min", 0.9);
+  auto rel_warn_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.relative_frequency_warn.max", 1.1);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(),
-    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
-    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
-    3
-  );
+    custom_diagnostic_tasks::RateBoundStatusParam(
+      frequency_reference * rel_ok_min_freq, frequency_reference * rel_ok_max_freq),
+    custom_diagnostic_tasks::RateBoundStatusParam(
+      frequency_reference * rel_warn_min_freq, frequency_reference * rel_warn_max_freq),
+    3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
   diag_composer->addTask(&(*rate_bound_status));
-  diag_updater->setPeriod(1.0 / target_frequency);
+  diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*diag_composer);
   diag_updater->force_update();
 

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -177,6 +177,7 @@ int main(int argc, char ** argv)
 
   auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
+    node.get(),
     custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
     custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
     3

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -56,8 +56,10 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/int32.hpp"
+#include "rate_bound_status.hpp"
 
 #include <sys/ioctl.h>
+#include <memory>
 
 std::string device = "/dev/ttyUSB0";
 std::string imu_type = "noGPS";
@@ -71,6 +73,9 @@ int counter;
 int raw_data;
 
 sensor_msgs::msg::Imu imu_msg;
+std::unique_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
+std::unique_ptr<diagnostic_updater::Updater> diag_updater;
+std::unique_ptr<diagnostic_updater::CompositeDiagnosticTask> diag_composer;
 
 int serial_setup(const char * device)
 {
@@ -170,6 +175,20 @@ int main(int argc, char ** argv)
   imu_msg.orientation.z = 0.0;
   imu_msg.orientation.w = 1.0;
 
+  auto target_frequency = node->declare_parameter<double>("target_frequency", 200.0);
+  rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
+    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.95, target_frequency * 1.05),
+    custom_diagnostic_tasks::RateBoundStatusParam(target_frequency * 0.90, target_frequency * 1.10),
+    3
+  );
+  diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
+  diag_updater->setHardwareID(imu_frame_id);
+  diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
+  diag_composer->addTask(&(*rate_bound_status));
+  diag_updater->setPeriod(1.0 / target_frequency);
+  diag_updater->add(*diag_composer);
+  diag_updater->force_update();
+
   while (rclcpp::ok()) {
     rclcpp::spin_some(node);
 
@@ -203,6 +222,7 @@ int main(int argc, char ** argv)
         imu_msg.linear_acceleration.z = raw_data * (100 / pow(2, 15));  // LSB & unit [m/s^2]
 
         pub->publish(imu_msg);
+        rate_bound_status->tick();
 
       } else if (rbuf[5] == 'V' && rbuf[6] == 'E' && rbuf[7] == 'R' && rbuf[8] == ',') {
         RCLCPP_DEBUG(rclcpp::get_logger("tag_serial_driver"), "%s", rbuf.c_str());

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -177,13 +177,13 @@ int main(int argc, char ** argv)
 
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
   auto ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.min", 190);
+    "diagnostics.rate_bound_status.frequency_ok.min_hz", 190.0);
   auto ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.max", 210);
+    "diagnostics.rate_bound_status.frequency_ok.max_hz", 210.0);
   auto warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.min", 180);
+    "diagnostics.rate_bound_status.frequency_warn.min_hz", 180.0);
   auto warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.max", 220);
+    "diagnostics.rate_bound_status.frequency_warn.max_hz", 220.0);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
     node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
     custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -190,7 +190,7 @@ int main(int argc, char ** argv)
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);
-  diag_composer->addTask(&(*rate_bound_status));
+  diag_composer->addTask(rate_bound_status.get());
   diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*diag_composer);
   diag_updater->force_update();

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -176,21 +176,17 @@ int main(int argc, char ** argv)
   imu_msg.orientation.w = 1.0;
 
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
-  auto rel_ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_ok.min", 0.95);
-  auto rel_ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_ok.max", 1.05);
-  auto rel_warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_warn.min", 0.9);
-  auto rel_warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.relative_frequency_warn.max", 1.1);
+  auto ok_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.min", 190);
+  auto ok_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.max", 210);
+  auto warn_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.min", 180);
+  auto warn_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.max", 220);
   rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
-    node.get(),
-    custom_diagnostic_tasks::RateBoundStatusParam(
-      frequency_reference * rel_ok_min_freq, frequency_reference * rel_ok_max_freq),
-    custom_diagnostic_tasks::RateBoundStatusParam(
-      frequency_reference * rel_warn_min_freq, frequency_reference * rel_warn_max_freq),
-    3);
+    node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
+    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 3);
   diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
   diag_updater->setHardwareID(imu_frame_id);
   diag_composer = std::make_unique<diagnostic_updater::CompositeDiagnosticTask>(imu_frame_id);


### PR DESCRIPTION
This PR adds diagnostics for topic rate monitoring with respect to design proposed in https://github.com/tier4/ros2_v4l2_camera/pull/29

Example output:
```
header:
  stamp:
    sec: 1748493384
    nanosec: 904007688
  frame_id: ''
status:
- level: "\0"
  name: '/tag_can_driver: rate bound check'
  message: Rate is reasonable
  hardware_id: imu
  values:
  - key: Publish rate
    value: '199.87'
  - key: Rate status
    value: OK
  - key: Minimum OK rate threshold
    value: '190.00'
  - key: Maximum OK rate threshold
    value: '210.00'
  - key: Minimum WARN rate threshold
    value: '180.00'
  - key: Maximum WARN rate threshold
    value: '220.00'
  - key: Observed frames
    value: '1'
  - key: Assumed skipped frames
    value: '0'
  - key: Observed frames transition threshold
    value: '3'
```