### PR TITLE
feat: refator serial driver

### DIFF
--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -60,155 +60,51 @@
 
 #include <sys/ioctl.h>
 #include <memory>
+#include <thread>
 
-std::string device = "/dev/ttyUSB0";
-std::string imu_type = "noGPS";
-std::string rate = "50";
 
-struct termios old_conf_tio;
-struct termios conf_tio;
-
-int fd;
-int counter;
-int raw_data;
-
-sensor_msgs::msg::Imu imu_msg;
-std::unique_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
+std::shared_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status;
 std::unique_ptr<diagnostic_updater::Updater> diag_updater;
 
-int serial_setup(const char * device)
-{
-  int fd = open(device, O_RDWR);
-
-  speed_t BAUDRATE = B115200;
-
-  conf_tio.c_cflag += CREAD;   // 受信有効
-  conf_tio.c_cflag += CLOCAL;  // ローカルライン（モデム制御なし）
-  conf_tio.c_cflag += CS8;     // データビット:8bit
-  conf_tio.c_cflag += 0;       // ストップビット:1bit
-  conf_tio.c_cflag += 0;
-
-  cfsetispeed(&conf_tio, BAUDRATE);
-  cfsetospeed(&conf_tio, BAUDRATE);
-
-  tcsetattr(fd, TCSANOW, &conf_tio);
-  ioctl(fd, TCSETS, &conf_tio);
-  return fd;
-}
-
-void receive_ver_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
-{
-  char ver_req[] = "$TSC,VER*29\x0d\x0a";
-  int ver_req_data = write(fd, ver_req, sizeof(ver_req));
-  if (ver_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Version Request: %s", ver_req);
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Version Request: %s", ver_req);
-  }
-}
-
-void receive_offset_cancel_req(const std_msgs::msg::Int32::ConstSharedPtr msg)
-{
-  char offset_cancel_req[32];
-  sprintf(offset_cancel_req, "$TSC,OFC,%d\x0d\x0a", msg->data);
-  int offset_cancel_req_data = write(fd, offset_cancel_req, sizeof(offset_cancel_req));
-  if (offset_cancel_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Offset Cancel Request: %s", offset_cancel_req);
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Offset Cancel Request: %s", offset_cancel_req);
-  }
-
-}
-
-void receive_heading_reset_req([[maybe_unused]] const std_msgs::msg::Int32::ConstSharedPtr msg)
-{
-  char heading_reset_req[] = "$TSC,HRST*29\x0d\x0a";
-  int heading_reset_req_data = write(fd, heading_reset_req, sizeof(heading_reset_req));
-  if (heading_reset_req_data >= 0) {
-    RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Send Heading reset Request: %s", heading_reset_req);
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "ERROR! Send Heading reset Request: %s", heading_reset_req);
-  }
-}
-
-void shutdown_cmd([[maybe_unused]] int sig)
-{
-  tcsetattr(fd, TCSANOW, &old_conf_tio);  // Revert to previous settings
-  close(fd);
-  RCLCPP_INFO(rclcpp::get_logger("tag_serial_driver"), "Port closed");
-  rclcpp::shutdown();
-}
 
 #include <boost/asio.hpp>
 using namespace boost::asio;
 
-int main(int argc, char ** argv)
+void loop_process(
+  rclcpp::Node::SharedPtr node,
+  boost::asio::serial_port &serial_port,
+  std::string imu_frame_id,
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub,
+  std::shared_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status
+)
 {
-  rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("tag_serial_driver");
-  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 1000);
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub1 = node->create_subscription<std_msgs::msg::Int32>("receive_ver_req", 10, receive_ver_req);
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub2 = node->create_subscription<std_msgs::msg::Int32>("receive_offset_cancel_req", 10, receive_offset_cancel_req);
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub3 = node->create_subscription<std_msgs::msg::Int32>("receive_heading_reset_req", 10, receive_heading_reset_req);
-
-  std::string imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
-
-  std::string port = node->declare_parameter<std::string>("port", "/dev/ttyUSB0");
-
-  io_service io;
-  serial_port serial_port(io, port.c_str());
-  serial_port.set_option(serial_port_base::baud_rate(115200));
-  serial_port.set_option(serial_port_base::character_size(8));
-  serial_port.set_option(serial_port_base::flow_control(serial_port_base::flow_control::none));
-  serial_port.set_option(serial_port_base::parity(serial_port_base::parity::none));
-  serial_port.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
-
-  std::string wbuf = "$TSC,BIN,30\x0d\x0a";
   std::size_t length;
-  serial_port.write_some(buffer(wbuf));
-
-  rclcpp::Rate loop_rate(30.0);
-
+  int raw_data;
+  std::string rbuf;
+  sensor_msgs::msg::Imu imu_msg;
   imu_msg.orientation.x = 0.0;
   imu_msg.orientation.y = 0.0;
   imu_msg.orientation.z = 0.0;
   imu_msg.orientation.w = 1.0;
 
-  auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
-  auto ok_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.min_hz", 100.0);
-  auto ok_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_ok.max_hz", 10000.0);
-  auto warn_min_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.min_hz", 50.0);
-  auto warn_max_freq = node->declare_parameter<double>(
-    "diagnostics.rate_bound_status.frequency_warn.max_hz", 100000.0);
-  node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
-  rate_bound_status = std::make_unique<custom_diagnostic_tasks::RateBoundStatus>(
-    node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
-    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 2, false);
-  diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
-  diag_updater->setHardwareID(imu_frame_id);
-  diag_updater->setPeriod(1.0 / frequency_reference);
-  diag_updater->add(*rate_bound_status);
-  diag_updater->force_update();
-
   while (rclcpp::ok()) {
-    rclcpp::spin_some(node);
-
     boost::asio::streambuf response;
-    boost::asio::read_until(serial_port, response, "\n");
-    std::string rbuf(
-      boost::asio::buffers_begin(response.data()), boost::asio::buffers_end(response.data()));
+    try {
+      boost::asio::read_until(serial_port, response, "\n");
+      rbuf = std::string(
+        boost::asio::buffers_begin(response.data()), boost::asio::buffers_end(response.data()));
+      length = rbuf.size();
+    } catch (boost::system::system_error &e) {
+      RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Error reading from serial port: %s", e.what());
+      continue;
+    }
 
-    length = rbuf.size();
 
     if (length > 0) {
       if (rbuf[5] == 'B' && rbuf[6] == 'I' && rbuf[7] == 'N' && rbuf[8] == ',' && length == 58) {
         imu_msg.header.frame_id = imu_frame_id;
         imu_msg.header.stamp = node->now();
 
-        counter = ((rbuf[11] << 8) & 0x0000FF00) | (rbuf[12] & 0x000000FF);
         raw_data = ((((rbuf[15] << 8) & 0xFFFFFF00) | (rbuf[16] & 0x000000FF)));
         imu_msg.angular_velocity.x =
           raw_data * (200 / pow(2, 15)) * M_PI / 180;  // LSB & unit [deg/s] => [rad/s]
@@ -232,6 +128,61 @@ int main(int argc, char ** argv)
         RCLCPP_DEBUG(rclcpp::get_logger("tag_serial_driver"), "%s", rbuf.c_str());
       }
     }
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("tag_serial_driver");
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 1000);
+
+  std::string imu_frame_id = node->declare_parameter<std::string>("imu_frame_id", "imu");
+  std::string port = node->declare_parameter<std::string>("port", "/dev/ttyUSB0");
+
+  io_service io;
+  serial_port serial_port(io);
+  try {
+    serial_port.open(port);
+    serial_port.set_option(serial_port_base::baud_rate(115200));
+    serial_port.set_option(serial_port_base::character_size(8));
+    serial_port.set_option(serial_port_base::flow_control(serial_port_base::flow_control::none));
+    serial_port.set_option(serial_port_base::parity(serial_port_base::parity::none));
+    serial_port.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
+  } catch (boost::system::system_error &e) {
+    RCLCPP_ERROR(rclcpp::get_logger("tag_serial_driver"), "Error opening serial port: %s", e.what());
+    return 1;
+  }
+
+  std::string wbuf = "$TSC,BIN,30\x0d\x0a";
+  serial_port.write_some(buffer(wbuf));
+
+  rclcpp::Rate loop_rate(30.0);
+
+  auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
+  auto ok_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.min_hz", 100.0);
+  auto ok_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_ok.max_hz", 10000.0);
+  auto warn_min_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.min_hz", 50.0);
+  auto warn_max_freq = node->declare_parameter<double>(
+    "diagnostics.rate_bound_status.frequency_warn.max_hz", 100000.0);
+  node->declare_parameter<bool>("diagnostic_updater.use_fqn", true);  // read by diagnostic updater
+  rate_bound_status = std::make_shared<custom_diagnostic_tasks::RateBoundStatus>(
+    node.get(), custom_diagnostic_tasks::RateBoundStatusParam(ok_min_freq, ok_max_freq),
+    custom_diagnostic_tasks::RateBoundStatusParam(warn_min_freq, warn_max_freq), 2, false);
+  diag_updater = std::make_unique<diagnostic_updater::Updater>(node);
+  diag_updater->setHardwareID(imu_frame_id);
+  diag_updater->setPeriod(1.0 / frequency_reference);
+  diag_updater->add(*rate_bound_status);
+
+  std::thread loop_thread(loop_process, node, std::ref(serial_port), imu_frame_id, pub, rate_bound_status);
+
+  rclcpp::spin(node);
+
+  if (loop_thread.joinable()) {
+    loop_thread.join();
   }
 
   return 0;

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -74,8 +74,7 @@ void loop_process(
   rclcpp::Node::SharedPtr node,
   boost::asio::serial_port &serial_port,
   std::string imu_frame_id,
-  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub,
-  std::shared_ptr<custom_diagnostic_tasks::RateBoundStatus> rate_bound_status
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub
 )
 {
   std::size_t length;
@@ -157,8 +156,6 @@ int main(int argc, char ** argv)
   std::string wbuf = "$TSC,BIN,30\x0d\x0a";
   serial_port.write_some(buffer(wbuf));
 
-  rclcpp::Rate loop_rate(30.0);
-
   auto frequency_reference = node->declare_parameter<double>("frequency_reference", 200.0);
   auto ok_min_freq = node->declare_parameter<double>(
     "diagnostics.rate_bound_status.frequency_ok.min_hz", 100.0);
@@ -177,7 +174,7 @@ int main(int argc, char ** argv)
   diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*rate_bound_status);
 
-  std::thread loop_thread(loop_process, node, std::ref(serial_port), imu_frame_id, pub, rate_bound_status);
+  std::thread loop_thread(loop_process, node, std::ref(serial_port), imu_frame_id, pub);
 
   rclcpp::spin(node);
 


### PR DESCRIPTION
# Description

- remove unused global variables
  - device
  - imu_type
  - rate
  - old_conf_tio
  - conf_tio
  - fd
  - raw_data -> local variables
- remove uused local variables
  - sub1
  - sub2
  - sub3
  - loop_rate
- remove functions
  - serial_setup
  - receive_ver_req
  - receive_heading_reset_req
  - shutdown_cmd
- execute while loop on another thread
- handle a exception about port process

# Test

1. prepare dummy serial port 
`sudo socat -d -d PTY,link=/dev/imu,mode=777 PTY,link=/dev/ttyDummy,mode=777`
2. prepare dummy imu data
```
    1 import serial
    2 import time
    3 
    4 ser = serial.Serial('/dev/ttyDummy', 115200)
    5 header = b"$TSC,BIN,"
    6 padding = b"A" * (58 - len(header) - 1)
    7 dummy_packet = header + padding + b"\n"
    8 
    9 print(f"Sending dummy data to /dev/ttyDummy (len={len(dummy_packet)})...")
   10 
   11 try:
   12     while True:
   13         ser.write(dummy_packet)
   14         time.sleep(0.001)
   15 except KeyboardInterrupt:
   16     ser.close()
   17     print("\nStopped.")
```
3. prepare test launch file
```
<?xml version="1.0" encoding="UTF-8"?>

<launch>
    <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver">
        <remap from="imu/data_raw" to="imu_raw"/>
        <param name="port" value="/dev/imu"/>
        <param name="imu_frame_id" value="tamagawa/imu_link"/>
    </node>
</launch>
```
4. Comfirmd /diagnocastcs and /imu_raw

[Screencast from 2026年03月13日 18時07分04秒.webm](https://github.com/user-attachments/assets/410d4f88-ee0f-4999-a4c7-062fb55e6607)

