### PR TITLE
feat: support cie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,19 @@ endif()
 
 ### Find Packages
 find_package(ament_cmake_auto REQUIRED)
+# if ENABLE_AGNOCAST environment variable is set to 1, enable agnocast components
+# and define a compile definition to conditionally compile code that depends on agnocast
+set(ENABLE_AGNOCAST_VAL "$ENV{ENABLE_AGNOCAST}")
+if(NOT DEFINED ENV{ENABLE_AGNOCAST} OR ENABLE_AGNOCAST_VAL STREQUAL "")
+  set(ENABLE_AGNOCAST_VAL "0")
+endif()
+
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+  find_package(agnocastlib REQUIRED)
+  find_package(agnocast_cie_thread_configurator REQUIRED)
+  add_compile_definitions(USE_AGNOCAST_ENABLED)
+endif()
+
 ament_auto_find_build_dependencies()
 
 ament_auto_add_executable(tag_serial_driver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
 if(ENABLE_AGNOCAST)
   find_package(agnocastlib REQUIRED)
   find_package(agnocast_cie_thread_configurator REQUIRED)
-  add_compile_definitions(USE_AGNOCAST_ENABLED)
 endif()
 
 ament_auto_find_build_dependencies()
@@ -40,7 +39,9 @@ ament_auto_add_executable(tag_can_driver
 )
 
 if(ENABLE_AGNOCAST)
+  target_compile_definitions(tag_can_driver PRIVATE USE_AGNOCAST_ENABLED)
   ament_target_dependencies(tag_can_driver agnocastlib)
+  target_compile_definitions(tag_serial_driver PRIVATE USE_AGNOCAST_ENABLED)
   ament_target_dependencies(tag_serial_driver agnocastlib agnocast_cie_thread_configurator)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,17 +13,12 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 # if ENABLE_AGNOCAST environment variable is set to 1, enable agnocast components
 # and define a compile definition to conditionally compile code that depends on agnocast
-set(ENABLE_AGNOCAST_DEFAULT "$ENV{ENABLE_AGNOCAST}")
-if(ENABLE_AGNOCAST_DEFAULT STREQUAL "1")
-  set(ENABLE_AGNOCAST_DEFAULT "ON")
-else()
-  # default to OFF when the environment variable is unset or not equal to "1"
-  set(ENABLE_AGNOCAST_DEFAULT "OFF")
+set(ENABLE_AGNOCAST_VAL "$ENV{ENABLE_AGNOCAST}")
+if(NOT DEFINED ENV{ENABLE_AGNOCAST} OR ENABLE_AGNOCAST_VAL STREQUAL "")
+  set(ENABLE_AGNOCAST_VAL "0")
 endif()
 
-option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
-
-if(ENABLE_AGNOCAST)
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
   find_package(agnocastlib REQUIRED)
   find_package(agnocast_cie_thread_configurator REQUIRED)
   add_compile_definitions(USE_AGNOCAST_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ ament_auto_add_executable(tag_can_driver
 	src/tag_can_driver.cpp
 )
 
+if(ENABLE_AGNOCAST)
+  ament_target_dependencies(tag_can_driver agnocastlib)
+  ament_target_dependencies(tag_serial_driver agnocastlib agnocast_cie_thread_configurator)
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,6 @@ ament_auto_add_executable(tag_can_driver
 	src/tag_can_driver.cpp
 )
 
-if(ENABLE_AGNOCAST)
-  ament_target_dependencies(tag_can_driver agnocastlib)
-  ament_target_dependencies(tag_serial_driver agnocastlib agnocast_cie_thread_configurator)
-endif()
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,17 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 # if ENABLE_AGNOCAST environment variable is set to 1, enable agnocast components
 # and define a compile definition to conditionally compile code that depends on agnocast
-set(ENABLE_AGNOCAST_VAL "$ENV{ENABLE_AGNOCAST}")
-if(NOT DEFINED ENV{ENABLE_AGNOCAST} OR ENABLE_AGNOCAST_VAL STREQUAL "")
-  set(ENABLE_AGNOCAST_VAL "0")
+set(ENABLE_AGNOCAST_DEFAULT "$ENV{ENABLE_AGNOCAST}")
+if(ENABLE_AGNOCAST_DEFAULT STREQUAL "1")
+  set(ENABLE_AGNOCAST_DEFAULT "ON")
+else()
+  # default to OFF when the environment variable is unset or not equal to "1"
+  set(ENABLE_AGNOCAST_DEFAULT "OFF")
 endif()
 
-if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
+
+if(ENABLE_AGNOCAST)
   find_package(agnocastlib REQUIRED)
   find_package(agnocast_cie_thread_configurator REQUIRED)
   add_compile_definitions(USE_AGNOCAST_ENABLED)

--- a/launch/test.launch.xml
+++ b/launch/test.launch.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<launch>
-    <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver">
-        <remap from="imu/data_raw" to="imu_raw"/>
-        <param name="port" value="/dev/imu"/>
-        <param name="imu_frame_id" value="tamagawa/imu_link"/>
-    </node>
-</launch>

--- a/launch/test.launch.xml
+++ b/launch/test.launch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+    <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver">
+        <remap from="imu/data_raw" to="imu_raw"/>
+        <param name="port" value="/dev/imu"/>
+        <param name="imu_frame_id" value="tamagawa/imu_link"/>
+    </node>
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocast_cie_thread_configurator</depend>
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>diagnostic_updater</depend>
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -51,6 +51,11 @@
 #include "sensor_msgs/msg/imu.hpp"
 
 #include "rate_bound_status.hpp"
+
+#ifdef USE_AGNOCAST_ENABLED
+#include <agnocast/agnocast_callback_isolated_executor.hpp>
+#endif
+
 #include <memory>
 
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
@@ -126,9 +131,16 @@ int main(int argc, char ** argv)
   diag_updater->setPeriod(1.0 / frequency_reference);
   diag_updater->add(*rate_bound_status);
   diag_updater->force_update();
-  rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);
   pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 100);
+  rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);
+  
+#ifdef USE_AGNOCAST_ENABLED
+  auto executor = std::make_shared<agnocast::CallbackIsolatedAgnocastExecutor>();
+  executor->add_node(node);
+  executor->spin();
+#else
   rclcpp::spin(node);
+#endif
 
   return 0;
 }

--- a/src/tag_can_driver.cpp
+++ b/src/tag_can_driver.cpp
@@ -133,7 +133,7 @@ int main(int argc, char ** argv)
   diag_updater->force_update();
   pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 100);
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub = node->create_subscription<can_msgs::msg::Frame>("/can/imu", 100, receive_CAN);
-  
+
 #ifdef USE_AGNOCAST_ENABLED
   auto executor = std::make_shared<agnocast::CallbackIsolatedAgnocastExecutor>();
   executor->add_node(node);

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -203,13 +203,13 @@ int main(int argc, char ** argv)
   const int timeout = static_cast<int>(1000.0 / (warn_min_freq * 0.1));  // ms
 
 #ifdef USE_AGNOCAST_ENABLED
-const std::string thread_name = "tag_serial_driver:" + port + "_loop_thread";
+  const std::string thread_name = "tag_serial_driver:" + port + "_loop_thread";
   std::thread loop_thread = agnocast_cie_thread_configurator::spawn_non_ros2_thread(
     thread_name.c_str(), loop_process, imu_frame_id, node, pub, timeout);
   auto executor = std::make_shared<agnocast::CallbackIsolatedAgnocastExecutor>();
   executor->add_node(node);
   executor->spin();
-#else 
+#else
   std::thread loop_thread(loop_process, imu_frame_id, node, pub, timeout);
   rclcpp::spin(node);
 #endif

--- a/src/tag_serial_driver.cpp
+++ b/src/tag_serial_driver.cpp
@@ -56,6 +56,11 @@
 
 #include <boost/asio.hpp>
 
+#ifdef USE_AGNOCAST_ENABLED
+#include <agnocast/agnocast_callback_isolated_executor.hpp>
+#include <agnocast_cie_thread_configurator/cie_thread_configurator.hpp>
+#endif
+
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
@@ -197,9 +202,17 @@ int main(int argc, char ** argv)
   diag_updater->add(*rate_bound_status);
   const int timeout = static_cast<int>(1000.0 / (warn_min_freq * 0.1));  // ms
 
-
+#ifdef USE_AGNOCAST_ENABLED
+const std::string thread_name = "tag_serial_driver:" + port + "_loop_thread";
+  std::thread loop_thread = agnocast_cie_thread_configurator::spawn_non_ros2_thread(
+    thread_name.c_str(), loop_process, imu_frame_id, node, pub, timeout);
+  auto executor = std::make_shared<agnocast::CallbackIsolatedAgnocastExecutor>();
+  executor->add_node(node);
+  executor->spin();
+#else 
   std::thread loop_thread(loop_process, imu_frame_id, node, pub, timeout);
   rclcpp::spin(node);
+#endif
 
   stop_io();
 


### PR DESCRIPTION
## Description

This PR enables **CallbackIsolatedAgnocastExecutor (CIE)** support for `tag_can_driver` and `tag_serial_driver`. This is part of the effort to achieve middleware-transparent scheduling and optimize end-to-end response time across Autoware.

In this package, `autoware_agnocast_wrapper` is not used (to avoid direct dependency). Instead, the environment variable `ENABLE_AGNOCAST` is used at **build time** to conditionally include Agnocast dependencies and switch the executor logic via the `USE_AGNOCAST_ENABLED` compile definition.

### Conditional Build Mechanism
- **If `ENABLE_AGNOCAST=1` during build:**
  - The macro `USE_AGNOCAST_ENABLED` is defined.
  - The node uses `agnocast::CallbackIsolatedAgnocastExecutor`.
  - In `tag_serial_driver`, the non-ROS 2 thread is spawned via `agnocast_cie_thread_configurator::spawn_non_ros2_thread` to enable scheduling configuration.
- **If `ENABLE_AGNOCAST` is unset or `0`:**
  - The node runs with the standard `rclcpp::spin` (default ROS 2 executor).
  - No dependency on Agnocast libraries is required for the build.

### Changes

- **CMakeLists.txt**: 
  - Added logic to check the `ENABLE_AGNOCAST` environment variable.
  - If enabled, finds `agnocastlib` and `agnocast_cie_thread_configurator` and adds the `USE_AGNOCAST_ENABLED` compile definition.
- **package.xml**: 
  - Added conditional dependencies for `agnocastlib` and `agnocast_cie_thread_configurator` using the `condition` attribute.
- **tag_can_driver.cpp**: 
  - Wrapped executor logic with `#ifdef USE_AGNOCAST_ENABLED` to switch between CIE and standard `rclcpp::spin`.
- **tag_serial_driver.cpp**: 
  - Switched between standard `std::thread` and `agnocast_cie_thread_configurator::spawn_non_ros2_thread` for the loop thread.
  - Wrapped executor logic with `#ifdef USE_AGNOCAST_ENABLED`.

## Related links

- [Autoware Discussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)

## How was this PR tested?

- **Build test**: Confirmed that the package builds successfully both with `ENABLE_AGNOCAST=0` (no Agnocast dependency) and `ENABLE_AGNOCAST=1`.
- **Execution test**: Verified that the nodes run with the expected executor in both modes.

## Notes for reviewers

**Please review the following aspects:**
- Verify that the manual macro-based switching (`#ifdef USE_AGNOCAST_ENABLED`) is correctly implemented and doesn't break the default ROS 2 build path.
- In `tag_serial_driver`, check the thread naming and configuration for `spawn_non_ros2_thread`.
- Check for potential race conditions:
  - When CIE is enabled, callback groups run in parallel. If the node was originally on a `SingleThreadedExecutor`, ensure shared variables are protected.

## Interface changes

None.

## Effects on system behavior

- **When `ENABLE_AGNOCAST=0` (default)**: No change in behavior. The node runs with the standard ROS 2 executor.
- **When `ENABLE_AGNOCAST=1`**: The executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). This allows for fine-grained scheduling of callback groups. For `tag_serial_driver`, the internal loop thread also becomes manageable under the Agnocast/CIE scheduling policy.